### PR TITLE
Fix for correctly displaying Panorama in Chrome for iOS

### DIFF
--- a/src/spritespin.js
+++ b/src/spritespin.js
@@ -828,13 +828,14 @@
       opts.frames = (data.frames || opts.resY);
     }
     
-    Module.draw(data);
+    Module.drawFirst(data);
   };
   
+  // The function was stripped to do only necessary CSS updates
   Module.draw = function(data){      
     var opts = data.modopts;
     var x, y;
-    
+       
     if (data.orientation == "horizontal"){
       x = (data.frame % opts.frames);
       y = 0;      
@@ -842,7 +843,23 @@
       x = 0;
       y = (data.frame % opts.frames);
     }
-    
+    data.stage.css({
+      "background-position"     : [-x, "px ", -y, "px"].join("")
+    });
+  };
+  
+   // Renamed original draw function which is called only once at Load/Reload
+  Module.drawFirst = function(data){      
+    var opts = data.modopts;
+    var x, y;
+
+    if (data.orientation == "horizontal"){
+      x = (data.frame % opts.frames);
+      y = 0;      
+    } else {
+      x = 0;
+      y = (data.frame % opts.frames);
+    }
     data.stage.css({
       width      : [data.width, "px"].join(""),
       height     : [data.height, "px"].join(""),


### PR DESCRIPTION
Fixes a flicker effect happening in Chrome for iOS (iPad)due to browser loading the image at each (panorama)Module.draw function call.
