### PR TITLE
fix bug where images loaded from chrome cache results in 0 WIDTH elements

### DIFF
--- a/src/spritespin.js
+++ b/src/spritespin.js
@@ -676,10 +676,13 @@
     var h = Math.floor(data.height || data.frameHeight || data.target.innerHeight());
     
     if (data.responsive && (typeof window.getComputedStyle === 'function')) {
-      var style = getComputedStyle(data.target[0]);
-      if (style.width) {
+      var styleWidth = getComputedStyle(data.target[0]).width;
+      // The image ("data.target[0]") can be loaded from the browser cache, which in some cases makes 
+      // "getComputedStyle().width" return the "auto" value (resulting in "w = 0").
+      // Not sure if the "inherit" and "inital" cases are possible, but it doesn't hurt to prevent.
+      if (styleWidth && styleWidth !== 'auto' && styleWidth !== 'inherit' && styleWidth !== 'initial') {
         var a = w / h;
-        w = Number(style.width.replace('px', ''))|0;
+        w = Number(styleWidth.replace('px', ''))|0;
         h = (w / a)|0;
       }
     }


### PR DESCRIPTION
In some chrome versions (linux 54.0 being one of them) sometimes the `getComputedStyle(data.target[0]).width` call in `Spin.setLayout` returns the value `auto` which makes the image width value 0 (` w = Number(style.width.replace('px', ''))|0; === 0`), thus making it invisible. 
It usually happens when spritesbin fully loaded the images, then you change to another page and then you go back to the previous page using the browser back button. My best guess is that chrome triggers the `img.onload` event for cached images without (or before) computing the image dimensions.