### PR TITLE
Prevent resize event triggering when mobile address bar disappears

### DIFF
--- a/src/spritespin.js
+++ b/src/spritespin.js
@@ -140,9 +140,16 @@
   }
 
   var resizeTimeout = null;
+  var cachedWidth = $(window).width();
   $(window).on('resize', function() {
-    clearTimeout(resizeTimeout);
-    resizeTimeout = setTimeout(handleResizeEvent, 100);
+    var newWidth = $(this).width();
+    // only triggers a resize when the width has changed
+	// this will prevent unwanted calls when the android|ios url address bar fades away
+    if (newWidth != cachedWidth) {
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(handleResizeEvent, 100);
+      cachedWidth = newWidth;
+    }
   });
 
   for (var i = 0; i < Spin.eventNames.length; i += 1) {


### PR DESCRIPTION
For android|ios browsers the address bar disappears when you scroll down the page, this triggers a resize event that will end up in a `Spin.boot(data);` call, which will reset the layout causing the page to reflow and "go up", it's extremely annoying.