### PR TITLE
Add willReadFrequently attribute to canvas.getContext()

### DIFF
--- a/lib/src/core/stage.ts
+++ b/lib/src/core/stage.ts
@@ -44,7 +44,7 @@ function grabCanvas(root: HTMLElement, parent: HTMLElement) {
 }
 
 function grabContext(canvas: HTMLCanvasElement) {
-  return canvas.getContext?.('2d')
+  return canvas.getContext?.('2d', { willReadFrequently: true })
 }
 
 function grabImages(parent: HTMLElement) {

--- a/lib/src/plugins/render-blur.ts
+++ b/lib/src/plugins/render-blur.ts
@@ -39,7 +39,7 @@ function init(e: Event, data: InstanceState) {
   if (!state.canvas || !state.canvas.parentElement) {
     state.canvas = state.canvas || document.createElement('canvas')
     state.canvas.classList.add('blur-layer')
-    state.context = state.context || state.canvas.getContext('2d')
+    state.context = state.context || state.canvas.getContext('2d', { willReadFrequently: true })
     css(state.canvas, {
       position: 'absolute',
       top: 0,

--- a/lib/src/utils/detectSubsampling.ts
+++ b/lib/src/utils/detectSubsampling.ts
@@ -13,7 +13,7 @@ function detectionContext() {
     return null
   }
 
-  context = canvas.getContext('2d')
+  context = canvas.getContext('2d', { willReadFrequently: true })
   return context
 }
 


### PR DESCRIPTION
Add `willReadFrequently` attribute to `canvas.getContext('2d')`.

Aditional info: 
Canvas2D: Multiple readback operations using getImageData are faster with the willReadFrequently attribute set to true. See: [https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently](https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently)